### PR TITLE
fix: use ConnectionProvider instead of wfGetDB

### DIFF
--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -30,7 +30,8 @@ return [
             $services->getUserOptionsLookup(),
             $services->getUserGroupManager(),
             $services->getMainWANObjectCache(),
-            $services->getObjectCacheFactory()->getLocalServerInstance( CACHE_HASH )
+            $services->getObjectCacheFactory()->getLocalServerInstance( CACHE_HASH ),
+            $services->getConnectionProvider()
         );
     },
 ];

--- a/includes/ThemeAndFeatureRegistry.php
+++ b/includes/ThemeAndFeatureRegistry.php
@@ -14,6 +14,7 @@ use MediaWiki\User\UserIdentity;
 use MediaWiki\User\UserOptionsLookup;
 use Wikimedia\ObjectCache\BagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class ThemeAndFeatureRegistry {
     public const SERVICE_NAME = 'ThemeToggle.ThemeAndFeatureRegistry';
@@ -36,7 +37,8 @@ class ThemeAndFeatureRegistry {
         private readonly UserOptionsLookup $userOptionsLookup,
         private readonly UserGroupManager $userGroupManager,
         private readonly WANObjectCache $wanObjectCache,
-        private readonly BagOStuff $hashCache
+        private readonly BagOStuff $hashCache,
+        private readonly IConnectionProvider $connectionProvider
     ) {
         $this->options->assertRequiredOptions( self::CONSTRUCTOR_OPTIONS );
     }
@@ -106,7 +108,7 @@ class ThemeAndFeatureRegistry {
                     self::CACHE_TTL,
                     function ( $old, &$ttl, &$setOpts ) {
                         // Reduce caching of known-stale data (T157210)
-                        $setOpts += Database::getCacheSetOptions( wfGetDB( DB_REPLICA ) );
+                        $setOpts += Database::getCacheSetOptions( $this->connectionProvider->getReplicaDatabase() );
                         return $this->loadFreshInternal();
                     },
                     [


### PR DESCRIPTION
wfGetDB has been deprecated since MW 1.39 and has started emitting warnings in 1.42.
The function will be removed in 1.44: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1134754